### PR TITLE
Hide dependencies in release drafter

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -59,6 +59,7 @@ categories:
   - title: ":lipstick: Style"
     label: "style"
   - title: ":package: Dependencies"
+    collapse-after: 1
     labels:
       - "dependencies"
       - "build"


### PR DESCRIPTION
- Clean up release notes by hiding dependencies.