### PR TITLE
chore: drop support for python 3.8

### DIFF
--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.8
+          python-version: 3.9
       - name: Install labels
         run: pip install labels
       - name: Sync config with Github

--- a/poetry.lock
+++ b/poetry.lock
@@ -702,25 +702,6 @@ perf = ["ipython"]
 testing = ["flake8 (<5)", "flufl.flake8", "importlib-resources (>=1.3)", "packaging", "pyfakefs", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.3)", "pytest-flake8", "pytest-mypy (>=0.9.1)", "pytest-perf (>=0.9.2)"]
 
 [[package]]
-name = "importlib-resources"
-version = "5.10.2"
-description = "Read resources from Python packages"
-category = "dev"
-optional = false
-python-versions = ">=3.7"
-files = [
-    {file = "importlib_resources-5.10.2-py3-none-any.whl", hash = "sha256:7d543798b0beca10b6a01ac7cafda9f822c54db9e8376a6bf57e0cbd74d486b6"},
-    {file = "importlib_resources-5.10.2.tar.gz", hash = "sha256:e4a96c8cc0339647ff9a5e0550d9f276fc5a01ffa276012b58ec108cfd7b8484"},
-]
-
-[package.dependencies]
-zipp = {version = ">=3.1.0", markers = "python_version < \"3.10\""}
-
-[package.extras]
-docs = ["furo", "jaraco.packaging (>=9)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-lint"]
-testing = ["flake8 (<5)", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.3)", "pytest-flake8", "pytest-mypy (>=0.9.1)"]
-
-[[package]]
 name = "iniconfig"
 version = "2.0.0"
 description = "brain-dead simple config-ini parsing"
@@ -829,7 +810,6 @@ files = [
 
 [package.dependencies]
 importlib-metadata = {version = ">=4.11.4", markers = "python_version < \"3.12\""}
-importlib-resources = {version = "*", markers = "python_version < \"3.9\""}
 "jaraco.classes" = "*"
 jeepney = {version = ">=0.4.2", markers = "sys_platform == \"linux\""}
 pywin32-ctypes = {version = ">=0.2.0", markers = "sys_platform == \"win32\""}
@@ -2112,5 +2092,5 @@ testing = ["flake8 (<5)", "func-timeout", "jaraco.functools", "jaraco.itertools"
 
 [metadata]
 lock-version = "2.0"
-python-versions = "^3.8.1"
-content-hash = "3e8e2ba90b5b1c7e7b64d6647c4bf0658bff00e693e9d24c1e53effd846fa6a0"
+python-versions = "^3.9"
+content-hash = "8a9383f4c5481ae98e6d40b47751d9958eaf2930ee6873180cb589319c3ab7d6"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,9 +6,9 @@ classifiers = [
   "License :: OSI Approved :: Apache Software License",
   "Natural Language :: English",
   "Programming Language :: Python",
-  "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
   "Topic :: Home Automation",
 ]
 description = "Control VLC over telnet connection using asyncio"
@@ -28,7 +28,7 @@ version = "0.2.1"
 
 [tool.poetry.dependencies]
 click = "^8.1.3"
-python = "^3.8.1"
+python = "^3.9"
 
 [tool.poetry.group.dev.dependencies]
 bandit = "^1.7.4"
@@ -139,7 +139,7 @@ load-plugins = [
   "pylint_strict_informational",
 ]
 persistent = false
-py-version = "3.8"
+py-version = "3.9"
 score = false
 
 [tool.pylint.FORMAT]
@@ -147,7 +147,6 @@ expected-line-ending-format = "LF"
 
 [tool.pylint."MESSAGES CONTROL"]
 disable = [
-  "consider-using-alias",
   "duplicate-code",
   "format",
   "locally-disabled",
@@ -171,6 +170,7 @@ pythonpath = ["src"]
 [tool.semantic_release]
 branch = "main"
 build_command = "pip install poetry && poetry build"
+major_on_zero = false
 version_toml = "pyproject.toml:tool.poetry.version"
 version_variable = "src/aiovlc/__init__.py:__version__"
 

--- a/src/aiovlc/cli/client_command.py
+++ b/src/aiovlc/cli/client_command.py
@@ -1,7 +1,7 @@
 """Provide a client."""
 import asyncio
+from collections.abc import Awaitable, Callable
 import logging
-from typing import Awaitable, Callable
 
 import click
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 import asyncio
-from typing import Generator
+from collections.abc import Generator
 from unittest.mock import AsyncMock, patch
 
 import pytest


### PR DESCRIPTION
BREAKING CHANGE: drop support for python 3.8

Minimum Python version is now 3.9.