### PR TITLE
fix: correctly parse volume with decimal seperator

### DIFF
--- a/src/aiovlc/model/command.py
+++ b/src/aiovlc/model/command.py
@@ -326,7 +326,7 @@ class Status(Command[StatusOutput]):
             input_loc_item = output.pop(0)
             input_loc = "%20".join(input_loc_item.split(" ")[3:-1])
         if len(output) == 2:
-            audio_volume = int(output[0].split(" ")[3])
+            audio_volume = int(float(output[0].split(" ")[3].replace(",", ".")))
             state = output[1].split(" ")[2]
         else:
             raise CommandParseError("Could not get status.")
@@ -356,7 +356,7 @@ class Volume(Command[VolumeOutput]):
     def parse_output(self, output: list[str]) -> VolumeOutput:
         """Parse command output."""
         try:
-            audio_volume = int(output[0])
+            audio_volume = int(float(output[0].replace(",", ".")))
         except (IndexError, ValueError) as err:
             raise CommandParseError("Could not get volume.") from err
         return VolumeOutput(audio_volume=audio_volume)

--- a/tests/model/test_command.py
+++ b/tests/model/test_command.py
@@ -423,15 +423,32 @@ async def test_set_volume_command_error(
     assert mock_writer.write.call_count == 0
 
 
+@pytest.mark.parametrize(
+    "read, audio_volume, state, input_loc",
+    [
+        (b"( audio volume: 0 )\r\n( state stopped )\r\n> ",
+         0, "stopped", None),
+        (b"( audio volume: 0.0 )\r\n( state stopped )\r\n> ",
+         0, "stopped", None),
+        (b"( audio volume: 0,0 )\r\n( state stopped )\r\n> ",
+         0, "stopped", None),
+        (b"( new input: file:///path/to/music.mp3 )\r\n( audio volume: 128.0 )\r\n( state paused )\r\n> ",
+         128, "paused", "file:///path/to/music.mp3"),
+        (b"( new input: file:///home/felix/Musik/Madonna - Jump.ogg )\r\n( audio volume: 256.0 )\r\n( state playing )\r\n> ",
+         256, "playing", "file:///home/felix/Musik/Madonna%20-%20Jump.ogg")
+    ]
+)
 async def test_status_command(
     transport: AsyncMock,
     client_connected: Client,
+    read: list[bytes],
+    audio_volume: int,
+    state: str,
+    input_loc: str | None
 ) -> None:
     """Test the status command."""
     mock_reader, mock_writer = transport.return_value
-    mock_reader.readuntil.return_value = (
-        b"( audio volume: 0 )\r\n( state stopped )\r\n> "
-    )
+    mock_reader.readuntil.return_value = read
 
     output = await client_connected.status()
 
@@ -439,9 +456,12 @@ async def test_status_command(
     assert mock_writer.write.call_args == call(b"status\n")
     assert mock_reader.readuntil.call_count == 1
     assert output
-    assert output.audio_volume == 0
-    assert output.state == "stopped"
-    assert output.input_loc is None
+    assert output.audio_volume == audio_volume
+    assert output.state == state
+    if input_loc is None:
+        assert output.input_loc is None
+    else:
+        assert output.input_loc == input_loc
 
 
 async def test_stop_command(

--- a/tests/model/test_command.py
+++ b/tests/model/test_command.py
@@ -485,3 +485,31 @@ async def test_stop_command(
     assert mock_writer.write.call_count == 1
     assert mock_writer.write.call_args == call(b"stop\n")
     assert mock_reader.readuntil.call_count == 1
+
+
+@pytest.mark.parametrize(
+    "read, audio_volume",
+    [
+        (b"0\r\n> ", 0),
+        (b"0.0\r\n> ", 0),
+        (b"0,0\r\n> ", 0),
+        (b"128.0\r\n> ", 128),
+    ],
+)
+async def test_volume_command(
+    transport: AsyncMock,
+    client_connected: Client,
+    read: list[bytes],
+    audio_volume: int,
+) -> None:
+    """Test the volume command."""
+    mock_reader, mock_writer = transport.return_value
+    mock_reader.readuntil.return_value = read
+
+    output = await client_connected.volume()
+
+    assert mock_writer.write.call_count == 1
+    assert mock_writer.write.call_args == call(b"volume\n")
+    assert mock_reader.readuntil.call_count == 1
+    assert output
+    assert output.audio_volume == audio_volume

--- a/tests/model/test_command.py
+++ b/tests/model/test_command.py
@@ -469,10 +469,7 @@ async def test_status_command(
     assert output
     assert output.audio_volume == audio_volume
     assert output.state == state
-    if input_loc is None:
-        assert output.input_loc is None
-    else:
-        assert output.input_loc == input_loc
+    assert output.input_loc == input_loc
 
 
 async def test_stop_command(

--- a/tests/model/test_command.py
+++ b/tests/model/test_command.py
@@ -430,13 +430,19 @@ async def test_set_volume_command_error(
         (b"( audio volume: 0.0 )\r\n( state stopped )\r\n> ", 0, "stopped", None),
         (b"( audio volume: 0,0 )\r\n( state stopped )\r\n> ", 0, "stopped", None),
         (
-            b"( new input: file:///path/to/music.mp3 )\r\n( audio volume: 128.0 )\r\n( state paused )\r\n> ",
+            (
+                b"( new input: file:///path/to/music.mp3 )\r\n"
+                b"( audio volume: 128.0 )\r\n( state paused )\r\n> "
+            ),
             128,
             "paused",
             "file:///path/to/music.mp3",
         ),
         (
-            b"( new input: file:///home/felix/Musik/Madonna - Jump.ogg )\r\n( audio volume: 256.0 )\r\n( state playing )\r\n> ",
+            (
+                b"( new input: file:///home/felix/Musik/Madonna - Jump.ogg )\r\n"
+                b"( audio volume: 256.0 )\r\n( state playing )\r\n> "
+            ),
             256,
             "playing",
             "file:///home/felix/Musik/Madonna%20-%20Jump.ogg",

--- a/tests/model/test_command.py
+++ b/tests/model/test_command.py
@@ -426,17 +426,22 @@ async def test_set_volume_command_error(
 @pytest.mark.parametrize(
     "read, audio_volume, state, input_loc",
     [
-        (b"( audio volume: 0 )\r\n( state stopped )\r\n> ",
-         0, "stopped", None),
-        (b"( audio volume: 0.0 )\r\n( state stopped )\r\n> ",
-         0, "stopped", None),
-        (b"( audio volume: 0,0 )\r\n( state stopped )\r\n> ",
-         0, "stopped", None),
-        (b"( new input: file:///path/to/music.mp3 )\r\n( audio volume: 128.0 )\r\n( state paused )\r\n> ",
-         128, "paused", "file:///path/to/music.mp3"),
-        (b"( new input: file:///home/felix/Musik/Madonna - Jump.ogg )\r\n( audio volume: 256.0 )\r\n( state playing )\r\n> ",
-         256, "playing", "file:///home/felix/Musik/Madonna%20-%20Jump.ogg")
-    ]
+        (b"( audio volume: 0 )\r\n( state stopped )\r\n> ", 0, "stopped", None),
+        (b"( audio volume: 0.0 )\r\n( state stopped )\r\n> ", 0, "stopped", None),
+        (b"( audio volume: 0,0 )\r\n( state stopped )\r\n> ", 0, "stopped", None),
+        (
+            b"( new input: file:///path/to/music.mp3 )\r\n( audio volume: 128.0 )\r\n( state paused )\r\n> ",
+            128,
+            "paused",
+            "file:///path/to/music.mp3",
+        ),
+        (
+            b"( new input: file:///home/felix/Musik/Madonna - Jump.ogg )\r\n( audio volume: 256.0 )\r\n( state playing )\r\n> ",
+            256,
+            "playing",
+            "file:///home/felix/Musik/Madonna%20-%20Jump.ogg",
+        ),
+    ],
 )
 async def test_status_command(
     transport: AsyncMock,
@@ -444,7 +449,7 @@ async def test_status_command(
     read: list[bytes],
     audio_volume: int,
     state: str,
-    input_loc: str | None
+    input_loc: str | None,
 ) -> None:
     """Test the status command."""
     mock_reader, mock_writer = transport.return_value


### PR DESCRIPTION
VLC has at some point started sending the volume as a number with a
decimal seperator, either a comma or period depending on the locale.
This causes a crash when reading the volume directly or from the status
command, because int() can't be called on a string that contains decimal
seperators.
Apparently, the volume can't be non-integer anyway: Setting it via the
GUI results in a fractional part of 0, and trying to set a non-integer
value via the telnet interface results in an error.

By replacing any commas with a period, the problem of users having to
adjust the locale of VLC is (hopefully) fixed.
Instead of casting the volume string into an int directly, it is now
first casted into a float and then into an int. This deals with the
crash.
